### PR TITLE
react-tap-event-plugin version fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "material-ui": "^0.15.4",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "webpack": "^1.13.2"
   },
   "repository": {


### PR DESCRIPTION
react-tap-event-plugin version fix for "ERROR in ./~/react-tap-event-plugin/src/TapEventPlugin.js" etc. errors when running.

For more info  https://stackoverflow.com/a/40747646/1290868